### PR TITLE
[fix]タイムゾーンの設定がUTCに戻っていたのでJSTに修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module SampleApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Railsをアップデートした際に、タイムゾーンの設定がUTCに戻っていたのでJSTに修正した。