### PR TITLE
ユーザーの更新・一覧表示・削除機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'jbuilder'
 
+gem 'will_paginate'
+gem 'bootstrap-will_paginate'
+
 gem 'bootsnap', require: false
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development do
   gem 'rubocop-rails', require: false
   gem 'debase'
   gem 'ruby-debug-ide'
+  gem 'faker'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap-will_paginate (1.0.0)
+      will_paginate
     builder (3.2.4)
     byebug (11.1.1)
     capybara (3.32.0)
@@ -256,6 +258,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    will_paginate (3.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -268,6 +271,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bootstrap-sass
+  bootstrap-will_paginate
   byebug
   capybara
   coffee-rails
@@ -296,6 +300,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   web-console
+  will_paginate
 
 BUNDLED WITH
    1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faker (2.11.0)
+      i18n (>= 1.6, < 2)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -271,6 +273,7 @@ DEPENDENCIES
   coffee-rails
   debase
   factory_bot_rails
+  faker
   jbuilder
   jquery-rails
   listen

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -188,3 +188,14 @@ input {
   width: auto;
   margin-left: 0;
 }
+
+/* Users index */
+.users {
+  list-style: none;
+  margin: 0;
+  li {
+    overflow: auto;
+    padding: 10px 0;
+    border-bottom: 1px solid $gray-lighter;
+  }
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       sign_in user
       params[:session][:remember_me] == '1' ? remember(user) : forget(user)
-      redirect_to user
+      redirect_back_or(user)
     else
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :correct_user, only: [:edit, :update]
 
   def index
-    @users = User.all
+    @users = User.paginate(page: params[:page])
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:edit, :update]
+  before_action :logged_in_user, only: [:index, :edit, :update]
   before_action :correct_user, only: [:edit, :update]
+
+  def index
+    @users = User.all
+  end
 
   def show
     @user = User.find(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :edit, :update]
+  before_action :logged_in_user, only: [:index, :edit, :update, :destroy]
   before_action :correct_user, only: [:edit, :update]
+  before_action :admin_user, only: :destroy
 
   def index
     @users = User.paginate(page: params[:page])
@@ -37,6 +38,12 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    User.find(params[:id]).destroy
+    flash[:success] = 'User deleted'
+    redirect_to users_path
+  end
+
   private
 
   def user_params
@@ -56,5 +63,10 @@ class UsersController < ApplicationController
   def correct_user
     @user = User.find(params[:id])
     redirect_to(root_url) unless current_user?(@user)
+  end
+
+  # 管理者かどうか確認
+  def admin_user
+    redirect_to(root_url) unless current_user.admin?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update]
+
   def show
     @user = User.find(params[:id])
   end
@@ -18,9 +21,36 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @user.update_attributes(user_params)
+      flash[:success] = 'Profile updated'
+      redirect_to @user
+    else
+      render 'edit'
+    end
+  end
+
   private
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+
+  # サインイン済みのユーザーかどうか確認
+  def logged_in_user
+    unless logged_in?
+      store_location
+      flash[:danger] = 'Please Sign in.'
+      redirect_to signin_url
+    end
+  end
+
+  # 正しいユーザーかどうか確認
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to(root_url) unless current_user?(@user)
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,10 +1,22 @@
 module SessionsHelper
-  # 渡されたユーザでログインする
+  # 渡されたユーザーでサインインする
   def sign_in(user)
     session[:user_id] = user.id
   end
 
-  # ユーザのセッションを永続的にする
+  # 現在のユーザーをサインアウトする
+  def sign_out
+    forget(current_user)
+    session.delete(:user_id)
+    @current_user = nil
+  end
+
+  # 渡されたユーザーがサインイン済みであればtrueを返す
+  def current_user?(user)
+    user == current_user
+  end
+
+  # 永続セッションとしてユーザーを記憶する
   def remember(user)
     user.remember
     cookies.permanent.signed[:user_id] = user.id
@@ -18,10 +30,14 @@ module SessionsHelper
     cookies.delete(:remember_token)
   end
 
-  # 現在のユーザをログアウトする
-  def sign_out
-    forget(current_user)
-    session.delete(:user_id)
-    @current_user = nil
+  # 記憶したURL(もしくはデフォルト値)にリダイレクト
+  def redirect_back_or(default)
+    redirect_to(session[:forwarding_url] || default)
+    session.delete(:forwarding_url)
+  end
+
+  # アクセスしようとしたURLを覚えておく
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,8 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: { case_sensitive: false }
   validates :password, presence: true,
-                       length: { minimum: 6 }
+                       length: { minimum: 6 },
+                       allow_nil: true
 
   class << self
     # 渡された文字列のハッシュ値を返す

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,7 +6,7 @@
         <li><%= link_to "Home", root_path %></li>
         <li><%= link_to "Help", help_path %></li>
         <% if logged_in? %>
-          <li><%= link_to 'Users', '#' %></li>
+          <li><%= link_to 'Users', users_path %></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
               Account <b class="caret"></b>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
             </a>
             <ul class="dropdown-menu">
               <li><%= link_to 'Profile', current_user %></li>
-              <li><%= link_to 'Settings', '#' %></li>
+              <li><%= link_to 'Settings', edit_user_path(current_user) %></li>
               <li class="divider"></li>
               <li><%= link_to 'Sign out', signout_path, method: :delete %></li>
             </ul>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_for(@user) do |f| %>
+  <%= render 'shared/error_messages' %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name, class: "form-control" %>
+
+  <%= f.label :email %>
+  <%= f.email_field :email, class: "form-control" %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password, class: "form-control" %>
+
+  <%= f.label :password_confirmation, "Confirmation" %>
+  <%= f.password_field :password_confirmation, class: "form-control" %>
+
+  <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,0 +1,4 @@
+<li>
+  <%= gravatar_for(user, size: 50) %>
+  <%= link_to(user.name, user) %>
+</li>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,4 +1,7 @@
 <li>
   <%= gravatar_for(user, size: 50) %>
   <%= link_to(user.name, user) %>
+  <% if current_user.admin? && !current_user?(user) %>
+    | <%= link_to "delete", user, method: :delete, data: { confirm: "You sure?" } %>
+  <% end %>
 </li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,14 @@
+<% provide(:title, 'Edit User') %>
+<% provide(:button_text, 'Save changes') %>
+
+<h1>Update your profile</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render 'form' %>
+    <div class="gravatar_edit">
+      <%= gravatar_for(@user) %>
+      <a href="http://gravatar.com/emails" target="_blank" rel="noopener">change</a>
+    </div>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,12 @@
+<% provide(:title, 'All users') %>
+
+<h1>All users</h1>
+
+<ul class="users">
+  <% @users.each do |user| %>
+    <li>
+      <%= gravatar_for(user, size: 50) %>
+      <%= link_to(user.name, user) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,11 +2,10 @@
 
 <h1>All users</h1>
 
+<%= will_paginate %>
+
 <ul class="users">
-  <% @users.each do |user| %>
-    <li>
-      <%= gravatar_for(user, size: 50) %>
-      <%= link_to(user.name, user) %>
-    </li>
-  <% end %>
+  <%= render @users %>
 </ul>
+
+<%= will_paginate %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,24 +1,10 @@
 <% provide(:title, 'Sign up') %>
+<% provide(:button_text, 'Create my account') %>
+
 <h1>Sign up</h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_for(@user) do |f| %>
-      <%= render 'shared/error_messages' %>
-
-      <%= f.label :name %>
-      <%= f.text_field :name, class: "form-control" %>
-
-      <%= f.label :email %>
-      <%= f.email_field :email, class: "form-control" %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: "form-control" %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: "form-control" %>
-
-      <%= f.submit "Create my account", class: "btn btn-primary" %>
-    <% end %>
+    <%= render 'form' %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,5 @@
 <% provide(:title, @user.name) %>
+
 <div class="row">
   <aside class="col-md-4">
     <section class="user_info">

--- a/db/migrate/20200415165402_add_admin_to_users.rb
+++ b/db/migrate/20200415165402_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_07_105709) do
+ActiveRecord::Schema.define(version: 2020_04_15_165402) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "name"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2020_04_07_105709) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.string "remember_digest"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,8 @@
 User.create!(name: 'Example User',
              email: 'example@railstutorial.org',
              password: 'foobar',
-             password_confirmation: 'foobar')
+             password_confirmation: 'foobar',
+             admin: true)
 
 99.times do |n|
   name = Faker::Name.name

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,14 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+User.create!(name: 'Example User',
+             email: 'example@railstutorial.org',
+             password: 'foobar',
+             password_confirmation: 'foobar')
+
+99.times do |n|
+  name = Faker::Name.name
+  email = "example-#{n + 1}@railstutorial.org"
+  password = 'password'
+  User.create!(name: name,
+               email: email,
+               password: password,
+               password_confirmation: password)
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,12 +8,6 @@ FactoryBot.define do
     password { 'password' }
   end
 
-  factory :another, class: User do
-    name { 'Another User' }
-    email { 'another@example.com' }
-    password { 'password' }
-  end
-
   factory :list_user, class: User do
     name
     email

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,13 @@
 FactoryBot.define do
-  factory :user do
+  factory :user, class: User do
     name { 'Test User' }
     email { 'test@example.com' }
+    password { 'password' }
+  end
+
+  factory :another, class: User do
+    name { 'Another User' }
+    email { 'another@example.com' }
     password { 'password' }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
+  sequence(:name) { |n| "Test User#{n}" }
+  sequence(:email) { |n| "test#{n}@example.com" }
+
   factory :user, class: User do
     name { 'Test User' }
     email { 'test@example.com' }
@@ -8,6 +11,12 @@ FactoryBot.define do
   factory :another, class: User do
     name { 'Another User' }
     email { 'another@example.com' }
+    password { 'password' }
+  end
+
+  factory :list_user, class: User do
+    name
+    email
     password { 'password' }
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe 'Sessions' , type: :request do
     context '有効な入力情報の時' do
       it 'サインインできること' do
         sign_in(signin_path, password: 'password')
+
+        # Profile Pageにリダイレクトされること
         expect(response).to redirect_to user
+
+        # サインインできること
         expect(is_signed_in?).to be_truthy
       end
     end
@@ -16,7 +20,11 @@ RSpec.describe 'Sessions' , type: :request do
     context '無効な入力情報の時' do
       it 'サインインできないこと' do
         sign_in(signin_path, password: 'invalid_password')
+
+        # sessions/newが再描画されること
         expect(response).to render_template('sessions/new')
+
+        # サインインできないこと
         expect(is_signed_in?).to be_falsey
       end
     end
@@ -42,11 +50,19 @@ RSpec.describe 'Sessions' , type: :request do
     context '有効な情報でログインしてからサインアウトする時' do
       it 'サインアウトできること' do
         sign_in(signin_path, password: 'password')
-        expect(is_signed_in?).to be_truthy
+
+        # Profile Pageにリダイレクトされること
         expect(response).to redirect_to user
+
+        # サインインできること
+        expect(is_signed_in?).to be_truthy
         delete signout_path
-        expect(is_signed_in?).to be_falsey
+
+        # Home Pageにリダイレクトされること
         expect(response).to redirect_to root_url
+
+        # サインインしていないこと
+        expect(is_signed_in?).to be_falsey
       end
     end
 
@@ -56,8 +72,12 @@ RSpec.describe 'Sessions' , type: :request do
         delete signout_path
         follow_redirect!
         delete signout_path
-        expect(is_signed_in?).to be_falsey
+
+        # Home Pageにリダイレクトされること
         expect(response).to redirect_to root_url
+
+        # サインインしていないこと
+        expect(is_signed_in?).to be_falsey
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -39,4 +39,115 @@ RSpec.describe 'Users', type: :request do
       end
     end
   end
+
+  describe '#edit' do
+    let!(:user) { create(:user) }
+
+    describe '#logged_in_user' do
+      context 'サインイン済みの時' do
+        before { sign_in(signin_path) }
+
+        it '自身のEdit Pageに遷移できること' do
+          get edit_user_path(user)
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context 'サインインしていない時' do
+        before { get edit_user_path(user) }
+
+        it '/signinにリダイレクトされること' do
+          expect(response).to redirect_to signin_url
+        end
+
+        context 'リダイレクト後にサインインした時' do
+          it '自身のEdit Pageに遷移できること' do
+            expect(sign_in(signin_path)).to redirect_to edit_user_path(user)
+          end
+
+          context '次回以降のサインインの時' do
+            it '自身のProfile Pageにリダイレクトされること' do
+              sign_in(signin_path)
+              delete signout_path
+              expect(sign_in(signin_path)).to redirect_to user
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    let!(:user) { create(:user) }
+
+    describe '#logged_in_user' do
+      context 'サインイン済みの時' do
+        before { sign_in(signin_path) }
+
+        context '有効な入力情報の時' do
+          let(:name) { 'Edit User' }
+          let(:email) { 'edit_test@example.com' }
+
+          context '全て入力した時' do
+            it 'ユーザー情報が更新されること' do
+              update_user(user_path(user), name: name, email: email)
+              user.reload
+              expect(user.name).to eq(name)
+              expect(user.email).to eq(email)
+            end
+          end
+
+          context 'password, password_confirmaitonを空にした時' do
+            it 'ユーザー情報が更新されること' do
+              update_user(user_path(user), name: name, email: email, password: '', confirmation: '')
+              user.reload
+              expect(user.name).to eq(name)
+              expect(user.email).to eq(email)
+            end
+          end
+        end
+
+        context '無効な入力情報の時' do
+          it '/users/edit/:idが再描画されること' do
+            update_user(user_path(user), confirmation: 'invalid')
+            expect(response).to render_template('users/edit')
+          end
+        end
+      end
+
+      context 'サインインしていない時' do
+        it '/signinにリダイレクトされること' do
+          response_without_sign_in = update_user(user_path(user))
+          expect(response_without_sign_in).to redirect_to signin_url
+        end
+      end
+    end
+  end
+
+  describe '#correct_user' do
+    let!(:user) { create(:user) }
+    let!(:another) { create(:another) }
+    before { sign_in(signin_path) }
+
+    describe '#edit' do
+      context '他ユーザーのEdit Pageにリクエストを送った時' do
+
+        it 'Home Pageにリダイレクトされること' do
+          another_user = User.find_by(email: 'another@example.com')
+          get edit_user_path(another_user)
+          expect(response).to redirect_to root_url
+        end
+      end
+    end
+
+    describe '#update' do
+      context '他ユーザーの情報を更新しようとした時' do
+        it 'Home Pageにリダイレクトされること' do
+          another_user = User.find_by(email: 'another@example.com')
+          update_user(user_path(another_user), name: 'Another Edit User')
+          expect(response).to redirect_to root_url
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -41,14 +41,21 @@ RSpec.describe 'Users', type: :request do
   end
 
   describe '#index' do
-    let!(:user) { create(:user) }
+    let!(:list_user) { create_list(:list_user, 31) }
 
     context 'サインイン済みの時' do
-      before { sign_in(signin_path) }
+      before { sign_in(signin_path, email: 'test1@example.com') }
 
-      it '200 OKを返すこと' do
+      it 'Usersページに30番目のユーザーが取得でき、31番目のユーザーが取得できないこと' do
         get users_path
+        # 200 OKを返すこと
         expect(response.status).to eq(200)
+
+        # 30番目のユーザーが取得できること
+        expect(response.body).to include('Test User30')
+
+        # 31番目のユーザーが取得できないこと
+        expect(response.body).not_to include('Test User31')
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -43,79 +43,25 @@ RSpec.describe 'Users', type: :request do
   describe '#index' do
     let!(:list_user) { create_list(:list_user, 31) }
 
-    context 'サインイン済みの時' do
-      before { sign_in(signin_path, email: 'test1@example.com') }
+    describe '#logged_in_user' do
+      context 'サインイン済みの時' do
+        before { sign_in(signin_path, email: 'test1@example.com') }
 
-      it 'Usersページに30番目のユーザーが取得でき、31番目のユーザーが取得できないこと' do
-        get users_path
-        # 200 OKを返すこと
-        expect(response.status).to eq(200)
+        it 'Usersページに30番目のユーザーが取得でき、31番目のユーザーが取得できないこと' do
+          get users_path
+          # 200 OKを返すこと
+          expect(response.status).to eq(200)
 
-        # 30番目のユーザーが取得できること
-        expect(response.body).to include('Test User30')
+          # 30番目のユーザーが取得できること
+          expect(response.body).to include('Test User30')
 
-        # 31番目のユーザーが取得できないこと
-        expect(response.body).not_to include('Test User31')
-      end
-    end
-  end
-
-  describe '#edit' do
-    let!(:user) { create(:user) }
-
-    context 'サインイン済みの時' do
-      before { sign_in(signin_path) }
-
-      it '200 OKを返すこと' do
-        get edit_user_path(user)
-        expect(response.status).to eq(200)
-      end
-    end
-  end
-
-  describe '#update' do
-    let!(:user) { create(:user) }
-
-    context 'サインイン済みの時' do
-      before { sign_in(signin_path) }
-
-      context '有効な入力情報の時' do
-        let(:name) { 'Edit User' }
-        let(:email) { 'edit_test@example.com' }
-
-        context '全て入力した時' do
-          it 'ユーザー情報が更新されること' do
-            update_user(user_path(user), name: name, email: email)
-            user.reload
-            expect(user.name).to eq(name)
-            expect(user.email).to eq(email)
-          end
-        end
-
-        context 'password, password_confirmaitonを空にした時' do
-          it 'ユーザー情報が更新されること' do
-            update_user(user_path(user), name: name, email: email, password: '', confirmation: '')
-            user.reload
-            expect(user.name).to eq(name)
-            expect(user.email).to eq(email)
-          end
+          # 31番目のユーザーが取得できないこと
+          expect(response.body).not_to include('Test User31')
         end
       end
 
-      context '無効な入力情報の時' do
-        it '/users/edit/:idが再描画されること' do
-          update_user(user_path(user), confirmation: 'invalid')
-          expect(response).to render_template('users/edit')
-        end
-      end
-    end
-  end
-
-  describe '#logged_in_user' do
-    let!(:user) { create(:user) }
-
-    describe '未サインイン' do
-      context '#index' do
+      context '未サインインの時' do
+        let!(:user) { create(:user) }
         before { get users_path }
 
         it '/signinにリダイレクトされること' do
@@ -138,8 +84,35 @@ RSpec.describe 'Users', type: :request do
           end
         end
       end
+    end
+  end
 
-      context '#edit' do
+  describe '#edit' do
+    let!(:user) { create(:user) }
+
+    describe '#logged_in_user' do
+      context 'サインイン済みの時' do
+        before { sign_in(signin_path) }
+
+        # correct_user
+        context '自身のEdit Pageにリクエストを送った時' do
+          it '200 OKを返すこと' do
+            get edit_user_path(user)
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context '他ユーザーのEdit Pageにリクエストを送った時' do
+          let!(:another) { create(:user, name: 'Another', email: 'another@example.com') }
+          it 'Home Pageにリダイレクトされること' do
+            another_user = User.find_by(email: 'another@example.com')
+            get edit_user_path(another_user)
+            expect(response).to redirect_to root_url
+          end
+        end
+      end
+
+      context '未サインインの時' do
         before { get edit_user_path(user) }
 
         it '/signinにリダイレクトされること' do
@@ -147,7 +120,7 @@ RSpec.describe 'Users', type: :request do
         end
 
         context 'リダイレクト後にサインインした時' do
-          it '自身の自身のEdit Pageにリダイレクトされること' do
+          it '自身のEdit Pageにリダイレクトされること' do
             sign_in(signin_path)
             expect(response).to redirect_to edit_user_path(user)
           end
@@ -162,8 +135,74 @@ RSpec.describe 'Users', type: :request do
           end
         end
       end
+    end
+  end
 
-      context '#update' do
+  describe '#update' do
+    let!(:user) { create(:user) }
+
+    describe '#logged_in_user' do
+      context 'サインイン済みの時' do
+        before { sign_in(signin_path) }
+
+        # correct_user
+        context '自身のユーザー情報を更新しようとした時' do
+          context '有効な入力情報の時' do
+            let(:name) { 'Edit User' }
+            let(:email) { 'edit_test@example.com' }
+
+            context '全て入力した時' do
+              it 'ユーザー情報が更新されること' do
+                update_user(user_path(user), name: name, email: email)
+                user.reload
+                expect(user.name).to eq(name)
+                expect(user.email).to eq(email)
+              end
+            end
+
+            context 'password, password_confirmaitonを空にした時' do
+              it 'ユーザー情報が更新されること' do
+                update_user(user_path(user),
+                            name: name,
+                            email: email,
+                            password: '',
+                            confirmation: '')
+                user.reload
+                expect(user.name).to eq(name)
+                expect(user.email).to eq(email)
+              end
+            end
+          end
+
+          context '無効な入力情報の時' do
+            it '/users/edit/:idが再描画されること' do
+              update_user(user_path(user), confirmation: 'invalid')
+              expect(response).to render_template('users/edit')
+            end
+          end
+
+          context "一般ユーザーが'admin'属性を更新しようとした時" do
+            it '更新できないこと' do
+              patch user_path(user), params: { user: { name: user.name,
+                                                       email: user.email,
+                                                       admin: 1 } }
+              user.reload
+              expect(user.admin?).to be_falsey
+            end
+          end
+        end
+
+        context '他ユーザーの情報を更新しようとした時' do
+          let!(:another) { create(:user, name: 'Another', email: 'another@example.com') }
+          it 'Home Pageにリダイレクトされること' do
+            another_user = User.find_by(email: 'another@example.com')
+            update_user(user_path(another_user), name: 'Another Edit')
+            expect(response).to redirect_to root_url
+          end
+        end
+      end
+
+      context '未サインインの時' do
         it '/signinにリダイレクトされること' do
           response_without_sign_in = update_user(user_path(user))
           expect(response_without_sign_in).to redirect_to signin_url
@@ -172,28 +211,38 @@ RSpec.describe 'Users', type: :request do
     end
   end
 
-  describe '#correct_user' do
-    let!(:user) { create(:user) }
-    let!(:another) { create(:another) }
-    before { sign_in(signin_path) }
+  describe '#destroy' do
+    let!(:user) { create(:user, admin: 1) }
+    let!(:another) { create(:user, name: 'Another', email: 'another@example.com', admin: 0) }
 
-    describe '#edit' do
-      context '他ユーザーのEdit Pageにリクエストを送った時' do
+    describe '#logged_in_user' do
+      context 'サインイン済みの時' do
+        context 'ユーザーがadminの時' do
+          before { sign_in(signin_path) }
+          it 'ユーザーが削除できること' do
+            # ユーザー数が-1になること
+            expect { delete user_path(another) }.to change(User, :count).by(-1)
+            # Users Pageにリダイレクトされること
+            expect(response).to redirect_to users_path
+          end
+        end
 
-        it 'Home Pageにリダイレクトされること' do
-          another_user = User.find_by(email: 'another@example.com')
-          get edit_user_path(another_user)
-          expect(response).to redirect_to root_url
+        context 'ユーザーがadminでない時' do
+          before { sign_in(signin_path, email: 'another@example.com') }
+
+          it 'ユーザーを削除できないこと' do
+            # ユーザー数が変化しないこと
+            expect { delete user_path(user) }.to change(User, :count).by(0)
+            # Home Pageにリダイレクトされること
+            expect(response).to redirect_to root_url
+          end
         end
       end
-    end
 
-    describe '#update' do
-      context '他ユーザーの情報を更新しようとした時' do
-        it 'Home Pageにリダイレクトされること' do
-          another_user = User.find_by(email: 'another@example.com')
-          update_user(user_path(another_user), name: 'Another Edit User')
-          expect(response).to redirect_to root_url
+      context '未サインインの時' do
+        before { delete user_path(user) }
+        it '/signinにリダイレクトされること' do
+          expect(response).to redirect_to signin_url
         end
       end
     end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -29,6 +29,17 @@ module Requests
                                    password: password,
                                    password_confirmation: confirmation } }
     end
+
+    def update_user(path,
+                    name: 'Edit User',
+                    email: 'edit_test@example.com',
+                    password: 'edit_password',
+                    confirmation: 'edit_password')
+      patch path, params: { user: { name: name,
+                                    email: email,
+                                    password: password,
+                                    password_confirmation: confirmation } }
+    end
   end
 end
 

--- a/spec/system/signup_pages_spec.rb
+++ b/spec/system/signup_pages_spec.rb
@@ -12,13 +12,22 @@ RSpec.describe 'Sign up', type: :system do
       end
 
       it 'サインアップできること' do
+        # Userテーブルにレコードが1件追加されること
         expect { click_button 'Create my account' }.to change(User, :count).by(1)
+
+        # サインアップしたユーザーのProfile Pageにリダイレクトすること
         user = User.last
         expect(current_path).to eq(user_path(user))
+
+        # 'Welcome to the Sample App!'と表示されること
         expect(page).to have_content('Welcome to the Sample App!')
 
+        # ナビゲーション
         within('.navbar-nav') do
+          # [Log in]リンクが非表示になること
           expect(page).not_to have_content('Log in')
+
+          # [Account]リンクが表示されること
           expect(page).to have_content('Account')
         end
       end
@@ -33,24 +42,30 @@ RSpec.describe 'Sign up', type: :system do
         fill_in 'Confirmation', with: 'invalid'
       end
 
-      it "'The form contains 1 error.'と表示されること" do
+      it 'サインアップできないこと' do
+        # Userテーブルにレコードが追加されないこと
         expect { click_button 'Create my account' }.to change(User, :count).by(0)
+
+        # 'The form contains 1 error.'と表示されること
         expect(page).to have_selector('div.alert.alert-danger', text: 'The form contains 1 error.')
       end
     end
 
-    context '無効な入力情報が複数(3つ)の時' do
+    context '無効な入力情報が複数(4つ)の時' do
       before do
         visit signup_path
-        fill_in 'Name', with: 'Test User'
-        fill_in 'Email', with: 'test@example.com'
+        fill_in 'Name', with: ''
+        fill_in 'Email', with: ''
         fill_in 'Password', with: ''
         fill_in 'Confirmation', with: ''
       end
 
-      it "'The form contains 3 errors.'と表示されること" do
+      it 'サインアップできないこと' do
+        # Userテーブルにレコードが追加されないこと
         expect { click_button 'Create my account' }.to change(User, :count).by(0)
-        expect(page).to have_selector('div.alert.alert-danger', text: 'The form contains 3 errors.')
+
+        # 'The form contains 4 errors.'と表示されること
+        expect(page).to have_selector('div.alert.alert-danger', text: 'The form contains 4 errors.')
       end
     end
   end

--- a/spec/system/user_pages_spec.rb
+++ b/spec/system/user_pages_spec.rb
@@ -1,13 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe 'User pages', type: :system do
-  subject { page }
+  let!(:user) { create(:user) }
 
   describe 'Profile page' do
-    let!(:user) { create(:user) }
-    before { visit user_path(user) }
+    context 'Profile Pageにアクセスした時' do
+      before { visit user_path(user) }
+      it 'ユーザー名が表示されること' do
+        expect(page).to have_content(user.name)
+      end
 
-    it { is_expected.to have_content(user.name) }
-    it { is_expected.to have_title(user.name) }
+      it 'ページタイトルがユーザー名であること' do
+        expect(page).to have_title(user.name)
+      end
+    end
+  end
+
+  describe 'User Edit Page' do
+    before { visit edit_user_path(user) }
+
+    context '有効な入力情報の時' do
+      before do
+        fill_in 'Name', with: 'Edit User'
+        fill_in 'Email', with: 'edit_test@example.com'
+        fill_in 'Password', with: 'edit_password'
+        fill_in 'Confirmation', with: 'edit_password'
+        click_button 'Save changes'
+      end
+
+      it '更新したユーザーのProfile Pageにリダイレクトすること' do
+        edit_user = User.find_by(email: 'edit_test@example.com')
+        expect(current_path).to eq(user_path(edit_user))
+      end
+
+      it "'Profile updated'と表示されること" do
+        expect(page).to have_content('Profile updated')
+      end
+    end
+
+    context '無効な入力情報が複数(4つ)の時' do
+      before do
+        fill_in 'Name', with: ''
+        fill_in 'Email', with: ''
+        fill_in 'Password', with: 'edit_password'
+        fill_in 'Confirmation', with: 'password'
+        click_button 'Save changes'
+      end
+
+      it "'The form contains 4 errors.'と表示されること" do
+        expect(page).to have_selector('div.alert.alert-danger', text: 'The form contains 4 errors.')
+      end
+    end
   end
 end


### PR DESCRIPTION
以下の機能、フィルタを追加した。
### 追加機能
- Users#edit
- Users#update
- Users#index
  - ページネーション
- Users#destroy
  - admin権限

### フィルタ
-  logged_in_user => ログイン済みであるか
- correct_user      => 正しいユーザーであるか
- admin_user        => admin権限のユーザーであるか

また、併せてRequest Specのリファクタリングも行った。