### PR TITLE
[update] Request Spec #29

### DIFF
--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -2,18 +2,33 @@ require 'rails_helper'
 
 RSpec.describe 'Sessions', type: :request do
   let!(:user) { create(:user) }
-  before { get signin_url }
 
   describe '#create' do
     context '有効な入力情報の時' do
-      it 'サインインできること' do
-        sign_in(signin_url, password: 'password')
+      context 'アカウントが有効化されている時' do
+        it 'サインインできること' do
+          sign_in(signin_url, password: 'password')
 
-        # Profile Pageにリダイレクトされること
-        expect(response).to redirect_to user
+          # Profile Pageにリダイレクトされること
+          expect(response).to redirect_to user
 
-        # サインインできること
-        expect(is_signed_in?).to be_truthy
+          # サインインできること
+          expect(is_signed_in?).to be_truthy
+        end
+      end
+
+      context 'アカウントが有効化されていない時' do
+        deactivated_params = { email: 'deactivated@example.com', activated: 0, activated_at: nil }
+        let!(:deactivated_user) { create(:user, deactivated_params) }
+        it 'サインインできないこと' do
+          sign_in(signin_url, email: 'deactivated@example.com')
+
+          # Home Pageにリダイレクトされること
+          expect(response).to redirect_to root_url
+
+          # サインインできないこと
+          expect(is_signed_in?).to be_falsey
+        end
       end
     end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Users', type: :request do
             it 'サインインできること' do
               get edit_account_activation_url(user.activation_token, email: user.email)
 
-              # ユーザーが有効化されること
+              # アカウントが有効化されること
               expect(user.reload.activated?).to be_truthy
 
               # サインインできること
@@ -89,21 +89,21 @@ RSpec.describe 'Users', type: :request do
         end
       end
 
-      context '有効化されていないユーザーが存在する時' do
+      context 'アカウントが有効化されていないユーザーが存在する時' do
         let!(:user) { create(:user) }
         deactivated_params = { name: 'Deactivated', email: 'deactivated@example.com', activated: 0, activated_at: nil }
         let!(:deactivated_user) { create(:user, deactivated_params) }
         before { sign_in(signin_url) }
 
-        it '有効化されていないユーザーが取得できないこと' do
+        it 'アカウントが有効化されていないユーザーが取得できないこと' do
           get users_url
           # 200 OKを返すこと
           expect(response.status).to eq(200)
 
-          # 有効化されていないユーザーが取得できないこと
+          # アカウントが有効化されていないユーザーが取得できないこと
           expect(response.body).not_to include('Deactivated')
 
-          # 有効化されているユーザーが取得できること
+          # アカウントが有効化されているユーザーが取得できること
           expect(response.body).to include('Test User')
         end
       end
@@ -137,7 +137,7 @@ RSpec.describe 'Users', type: :request do
 
   describe '#show' do
     context 'ユーザーが存在する時' do
-      context 'ユーザーが有効化されている時' do
+      context 'アカウントが有効化されている時' do
         let!(:user) { create(:user) }
         before { get user_url(user) }
 
@@ -150,7 +150,7 @@ RSpec.describe 'Users', type: :request do
         end
       end
 
-      context 'ユーザーが有効化されていない時' do
+      context 'アカウントが有効化されていない時' do
         deactivated_params = { activated: 0, activated_at: nil }
         let!(:deactivated_user) { create(:user, deactivated_params) }
         before { get user_url(deactivated_user) }


### PR DESCRIPTION
## Issue

[Issue#29](https://github.com/tom0418/rails-tutorial/issues/29)

## 内容

アカウント有効化機能の追加時に対応漏れとなっていた Sessions#create の Request Spec を修正した。

## 追加で対応したもの

- requests/users_spec.rb 文言修正
  - 有効化されるのはアカウントのため、文言を統一した。