### PR TITLE
[Add] Password reset

### DIFF
--- a/app/assets/javascripts/password_resets.coffee
+++ b/app/assets/javascripts/password_resets.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/password_resets.scss
+++ b/app/assets/stylesheets/password_resets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the PasswordResets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,18 @@
+class PasswordResetsController < ApplicationController
+  def new; end
+
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = 'Email sent with password reset instructions'
+      redirect_to root_url
+    else
+      flash.now[:danger] = 'Email address not found'
+      render 'new'
+    end
+  end
+
+  def edit; end
+end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,7 @@
 class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [:edit, :update]
+  before_action :valid_user, only: [:edit, :update]
+
   def new; end
 
   def create
@@ -15,4 +18,20 @@ class PasswordResetsController < ApplicationController
   end
 
   def edit; end
+
+  def update; end
+
+  private
+
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  # 正しいユーザーかどうか確認する
+  def valid_user
+    valid_user_conditions = @user && @user.activated? && @user.authenticated?(:reset, params[:id])
+    unless valid_user_conditions
+      redirect_to root_url
+    end
+  end
 end

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -26,6 +26,7 @@ class PasswordResetsController < ApplicationController
       render 'edit'
     elsif @user.update(user_params)
       sign_in @user
+      @user.update_attribute(:reset_digest, nil)
       flash[:success] = 'Password has been reset.'
       redirect_to @user
     else

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,9 +14,8 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.password_reset.subject
   #
-  def password_reset
-    @greeting = 'Hi'
-
-    mail to: 'to@example.org'
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: 'Password reset'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, User.digest(remember_token))
   end
 
-  # 渡されたトークンがダイジェストと一致したらtrueを返す
+  # 渡されたトークンがダイジェストと一致したら true を返す
   def authenticated?(attribute, token)
     digest = send("#{attribute}_digest")
     return false if digest.nil?
@@ -67,6 +67,11 @@ class User < ApplicationRecord
   # パスワード再設定のメールを送信する
   def send_password_reset_email
     UserMailer.password_reset(self).deliver_now
+  end
+
+  # パスワード再設定の期限が切れている場合は true を返す
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
   before_save :downcase_email
   before_create :create_activation_digest
   has_secure_password
@@ -56,6 +56,17 @@ class User < ApplicationRecord
   # 有効化用のメールを送信する
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  # パスワード再設定の属性を設定する
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+
+  # パスワード再設定のメールを送信する
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
   end
 
   private

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,2 +1,21 @@
-<h1>PasswordResets#edit</h1>
-<p>Find me in app/views/password_resets/edit.html.erb</p>
+<% provide(:title, 'Reset password') %>
+
+<h1>Reset password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user, url: password_reset_path(params[:id])) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: "form-control" %>
+
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
+
+      <%= f.submit "Update password", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -8,7 +8,7 @@
       <%= f.label :email %>
       <%= f.email_field :email, class: "form-control" %>
 
-      <%= f.submit "Sign in", class: "btn btn-primary" %>
+      <%= f.submit "Submit", class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,13 @@
+<% provide(:title, 'Forgot password') %>
+<h1>Forgot password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(:password_reset, url: password_resets_path) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit 'Sign in', class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,13 +1,14 @@
 <% provide(:title, 'Forgot password') %>
+
 <h1>Forgot password</h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_for(:password_reset, url: password_resets_path) do |f| %>
       <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
+      <%= f.email_field :email, class: "form-control" %>
 
-      <%= f.submit 'Sign in', class: 'btn btn-primary' %>
+      <%= f.submit "Sign in", class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -8,6 +8,7 @@
       <%= f.email_field :email, class: 'form-control' %>
 
       <%= f.label :password %>
+      <%= link_to "(forgot password)", new_password_reset_path %>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :remember_me, class: 'checkbox inline' do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,12 @@
-<h1>User#password_reset</h1>
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+  If you did not request your password to be reset, please ignore this email and
+  your password will stay as it is.
 </p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,8 @@
-User#password_reset
+To reset your password click the link below:
 
-<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
 
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets, only: [:new, :create, :edit, :update]
 end

--- a/db/migrate/20200501100737_add_reset_to_users.rb
+++ b/db/migrate/20200501100737_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_23_104648) do
+ActiveRecord::Schema.define(version: 2020_05_01_100737) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "name"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2020_04_23_104648) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -9,6 +9,8 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
-  let!(:user) { create(:user, activated: 0, activated_at: nil) }
-
   describe 'account_activation' do
+    let!(:user) { create(:user, activated: 0, activated_at: nil) }
     let(:mail) { UserMailer.account_activation(user) }
 
     it 'renders the headers' do
@@ -21,17 +20,21 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
-  # describe 'password_reset' do
-  #   let(:mail) { UserMailer.password_reset }
-  #
-  #   it 'renders the headers' do
-  #     expect(mail.subject).to eq('Password reset')
-  #     expect(mail.to).to eq(['to@example.org'])
-  #     expect(mail.from).to eq(['from@example.com'])
-  #   end
-  #
-  #   it 'renders the body' do
-  #     expect(mail.body.encoded).to match('Hi')
-  #   end
-  # end
+  describe 'password_reset' do
+    let!(:user) { create(:user) }
+    before { user.reset_token = User.new_token }
+    let(:mail) { UserMailer.password_reset(user) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Password reset')
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq(['noreply@example.com'])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match(user.reset_token)
+      user_email = CGI.escape(user.email)
+      expect(mail.body.encoded).to match(user_email)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe User, type: :model do
     it 'activation_token' do
       expect(user).to respond_to(:activation_token)
     end
+
+    it 'reset_token' do
+      expect(user).to respond_to(:reset_token)
+    end
   end
 
   describe 'インスタンスメソッド' do
@@ -52,6 +56,26 @@ RSpec.describe User, type: :model do
 
     it '#forget' do
       expect(user).to respond_to(:forget)
+    end
+
+    it '#activate' do
+      expect(user).to respond_to(:activate)
+    end
+
+    it '#send_activation_email' do
+      expect(user).to respond_to(:send_activation_email)
+    end
+
+    it '#create_reset_digest' do
+      expect(user).to respond_to(:create_reset_digest)
+    end
+
+    it '#send_password_reset_email' do
+      expect(user).to respond_to(:send_password_reset_email)
+    end
+
+    it '#password_reset_expired?' do
+      expect(user).to respond_to(:password_reset_expired?)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,5 @@ RSpec.configure do |config|
   config.include Requests::AuthenticationHelper, type: :request
   config.include Requests::SessionsHelper, type: :request
   config.include Requests::UsersHelper, type: :request
+  config.include Requests::PasswordResetsHelper, type: :request
 end

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe 'PasswordReset', type: :request do
+  let!(:user) { create(:user) }
+
+  describe '#create' do
+    context 'メールアドレスが無効な時' do
+      it "'password_resets/new'が再描画されること" do
+        reset_password(password_resets_url, email: '')
+        expect(response).to render_template('password_resets/new')
+      end
+    end
+
+    context 'メールアドレスが有効な時' do
+      it 'Home Pageにリダイレクトされること' do
+        reset_password(password_resets_url, email: user.email)
+        expect(response).to redirect_to root_url
+      end
+    end
+  end
+
+  describe '#edit' do
+    context 'メールアドレスが無効な時' do
+      it 'Home Pageにリダイレクトされること' do
+        reset_password(password_resets_url, email: user.email)
+        user = assigns(:user)
+        get edit_password_reset_url(user.reset_token, email: '')
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'メールアドレスが有効な時' do
+      context 'アカウントが無効な時' do
+        before { user.toggle!(:activated) }
+
+        it 'Home Pageにリダイレクトされること' do
+          reset_password(password_resets_url, email: user.email)
+          user = assigns(:user)
+          get edit_password_reset_url(user.reset_token, email: user.email)
+          expect(response).to redirect_to root_url
+        end
+      end
+
+      context 'アカウントが有効な時' do
+        before { reset_password(password_resets_url, email: user.email) }
+
+        context 'reset_tokenが無効な時' do
+          it 'Home Pageにリダイレクトされること' do
+            user = assigns(:user)
+            get edit_password_reset_url('wrong token', email: user.email)
+            expect(response).to redirect_to root_url
+          end
+        end
+
+        context 'reset_tokenが有効な時' do
+          context 'パスワード再設定が期限切れの時' do
+            it "'password_resets/new'にリダイレクトされること" do
+              user = assigns(:user)
+              expired_time = user.reset_sent_at - 2.hours
+              user.update(reset_sent_at: expired_time)
+              user.reload
+              get edit_password_reset_url(user.reset_token, email: user.email)
+              expect(response).to redirect_to new_password_reset_url
+            end
+          end
+
+          context 'パスワード再設定が期限切れでない時' do
+            it 'Reset password Pageに遷移すること' do
+              user = assigns(:user)
+              get edit_password_reset_url(user.reset_token, email: user.email)
+
+              # 200 OKを返すこと
+              expect(response.status).to eq(200)
+
+              # password_resets/editが表示されること
+              expect(response).to render_template('password_resets/edit')
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'メールアドレスが無効な時' do
+      it 'Home Pageにリダイレクトされること' do
+        reset_password(password_resets_url, email: user.email)
+        user = assigns(:user)
+        update_password(password_reset_url(user.reset_token), email: '')
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'メールアドレスが有効な時' do
+      context 'アカウントが無効な時' do
+        before { user.toggle!(:activated) }
+
+        it 'Home Pageにリダイレクトされること' do
+          reset_password(password_resets_url, email: user.email)
+          user = assigns(:user)
+          update_password(password_reset_url(user.reset_token), email: user.email)
+          expect(response).to redirect_to root_url
+        end
+      end
+
+      context 'アカウントが有効な時' do
+        before { reset_password(password_resets_url, email: user.email) }
+
+        context 'reset_tokenが無効な時' do
+          it 'Home Pageにリダイレクトされること' do
+            user = assigns(:user)
+            update_password(password_reset_url('wrong token'), email: user.email)
+            expect(response).to redirect_to root_url
+          end
+        end
+
+        context 'reset_tokenが有効な時' do
+          context 'パスワード再設定が期限切れの時' do
+            it "'password_resets/new'にリダイレクトされること" do
+              user = assigns(:user)
+              expired_time = user.reset_sent_at - 2.hours
+              user.update(reset_sent_at: expired_time)
+              user.reload
+              update_password(password_reset_url(user.reset_token), email: user.email)
+              expect(response).to redirect_to new_password_reset_url
+            end
+          end
+
+          context 'パスワード再設定が期限切れでない時' do
+            context 'passwordが空の時' do
+              it "'password_resets/edit'が再描画されること" do
+                user = assigns(:user)
+                update_password(password_reset_url(user.reset_token), email: user.email, password: '')
+                expect(response).to render_template('password_resets/edit')
+              end
+            end
+
+            context 'password_confirmationが空の時' do
+              it "'password_resets/edit'が再描画されること" do
+                user = assigns(:user)
+                update_password(password_reset_url(user.reset_token), email: user.email, confirmation: '')
+                expect(response).to render_template('password_resets/edit')
+              end
+            end
+
+            context 'password, password_confirmationが有効な時' do
+              it 'Profile Pageにリダイレクトされること' do
+                user = assigns(:user)
+                update_password(password_reset_url(user.reset_token), email: user.email)
+
+                # サインインすること
+                expect(is_signed_in?).to be_truthy
+
+                # Profile Pageにリダイレクトされること
+                expect(response).to redirect_to user
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -41,4 +41,19 @@ module Requests
                                    password_confirmation: confirmation } }
     end
   end
+
+  module PasswordResetsHelper
+    def reset_password(url, email: 'test@example.com')
+      post url, params: { password_reset: { email: email } }
+    end
+
+    def update_password(url,
+                        email: 'test@example.com',
+                        password: 'edit_password',
+                        confirmation: 'edit_password')
+      patch url, params: { email: email,
+                           user: { password: password,
+                                   password_confirmation: confirmation } }
+    end
+  end
 end


### PR DESCRIPTION
## 内容

パスワード再設定機能の全体の流れは以下である。

1. ユーザーがパスワードの再設定をリクエストすると、ユーザーが送信したメールアドレスを
キーにしてDBからユーザーを取得する

1. 該当のメールアドレスがDBに存在する場合は、再設定用のトークンとそれに対応するリセッ
トダイジェストを生成する

1. リセットダイジェストはDBに保存しておき、再設定用トークンはメールアドレスと一緒に、
ユーザーに送信する有効化用メールのリンクに仕込んでおく

1. ユーザーが有効化用メールのリンクをクリックしたら、メールアドレスをキーとしてDBから
ユーザーを取得し、DBに保存しておいたリセットダイジェストと比較（トークンを認証）する

1. 認証に成功したら、パスワード変更用のフォームをユーザーに表示する

## 対応一覧

### Controller

- [x] PasswordResets コントローラの作成（new, create, edit, update）

#### aciton

- [x] new
  - [x] メールアドレス入力フォームを表示する

- [x] create
  - [x] メールアドレスをキーとしてDBからユーザーを取得する
  - [x] ユーザーの取得に成功した場合、以下の処理を行う
    - [x] 再設定用トークンとそれに対応するリセットダイジェストの生成
    - [x] パスワード再設定用のメール送信
    - [x] ホーム画面にリダイレクトする
  - [x] ユーザーの取得に失敗した場合、メールアドレス入力フォームを再描画する

- [x] before filter（edit, update）
  - [x] メールアドレスをキーとしてDBからユーザーを取得する
  - [x] 正しいユーザーかどうか確認する
    - [x] メールアドレスが正しいか
    - [x] アカウントが有効であるか
    - [x] トークン認証
  - [x] パスワードの有効期限が切れていないか

- [x] edit
    - [x] パスワード再設定フォームを表示する

- [x] update
  - [x] 無効なパスワードであればエラーを返す（エラーメッセージの表示）
  - [x] 新しいパスワードが空文字になっていないかのバリデーション（ユーザー情報編集ではOK）
    - [x] エラーメッセージを追加する
  - [x] 新しいパスワードが正しければ更新する
  - [x] パスワードの更新が失敗した場合、パスワード再設定フォームを再描画する
  - [x] パスワードの更新が成功した場合、ユーザー詳細ページにリダイレクトする

### ルーティング

- [x] ルーティングの追加（new, create, edit, update）

### Model

- [x] User モデルへの属性、メソッド追加
  - [x] 属性
    - [x] reset_digest: リセットダイジェスト
    - [x] reset_sent_at: 再設定メールの送信時刻

  - [x] アクセサ
    - [x] 再設定用トークン

  - [x] メソッド
    - [x] 再設定用トークンとそれに対応するダイジェストの生成
    - [x] パスワード再設定用メールの送信

### View

- [x] サインインページにパスワード再設定用のリンクを追加

- [x] 各種フォーム作成
  - [x] メールアドレス入力フォーム
  - [x] パスワード再設定フォーム

- [x] パスワード再設定メールのテンプレート作成
  - [x] リンクに再設定用トークン、メールアドレスを仕込む

### Mailer

- [x] UserMailer に password_reset を追加

### Test

- [x] RSpec
  - [x] Model Spec
  - [x] Request Spec