### PR TITLE
[Upgrade] websocket-extensions to 0.1.5 from 0.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     will_paginate (3.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)


### PR DESCRIPTION
## 概要

websocket-extensionsを0.1.4から0.1.5にアップデートした。